### PR TITLE
[Fix]carts-link

### DIFF
--- a/app/views/public/carts_items/index.html.erb
+++ b/app/views/public/carts_items/index.html.erb
@@ -52,7 +52,7 @@
         <% end %>
         </tbody>
       </table>
-      <%= link_to "買い物を続ける", items_path, class: "btn btn-secondary" %>
+      <%= link_to "買い物を続ける", root_path, class: "btn btn-secondary" %>
       <div class="row justify-content-end">
         <div class="co-5">
           <table class="table table-bordered text-left" style="width: 300px;">


### PR DESCRIPTION
買い物を続けるボタンのlink先をトップページに変更しました。